### PR TITLE
Account for dependency path being shorter than 11

### DIFF
--- a/internal/cmd/versions.go
+++ b/internal/cmd/versions.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/anorth/rehab/internal/db"
 	"github.com/anorth/rehab/pkg/model"
@@ -99,7 +100,7 @@ func FindStaleVersions(modules *db.Modules, modGraph *db.ModGraph) []*StaleVersi
 				// Trace through deeper in the requirement graph only for the version of the upstream
 				// that is the one selected by MVS.
 				_, seen := modulesSeen[req.Upstream.Path]
-				if !seen && req.Upstream.Path[:11] != "golang.org/" { // Replace with whitelist?
+				if !seen && (! strings.HasPrefix(req.Upstream.Path, "golang.org/")) { // Replace with whitelist?
 					q = append(q, req.Upstream)
 					modulesSeen[req.Upstream.Path] = struct{}{}
 				}


### PR DESCRIPTION
This PR makes `rehab show` succeed for modules that have dependencies with paths shorter than 11 characters - e.g. `go4.org` (see https://github.com/ipfs/go-fs-lock/blob/45ea93f2c0ea26375bce8326359da964cfdcee85/go.mod).

It does so by replacing taking the first 11 characters of the path with checking if a specified prefix matches using `strings.HasPrefix` function.

###### Testing
- [x] `rehab --token="" show --all -v .` succeeded in `ipfs/go-ds-s3` which transitively depends on `go4.org`

